### PR TITLE
fix(lpc): clamp diverging edge extrapolation before it overflows the DFT

### DIFF
--- a/ardftsrc/src/lpc.rs
+++ b/ardftsrc/src/lpc.rs
@@ -8,6 +8,12 @@ use num_traits::Float;
 /// Maximum LPC order used during extrapolation.
 pub(crate) const EXTRAPOLATION_MAX_ORDER: usize = 64;
 
+/// Bound on predicted magnitude relative to the seed window's peak. A stable
+/// predictor of bounded audio has no business exceeding the seed's peak by
+/// orders of magnitude; once a prediction crosses this line the recursion has
+/// diverged and every later value is garbage on its way to overflow.
+pub(crate) const EXTRAPOLATION_DIVERGENCE_HEADROOM: f64 = 8.0;
+
 /// Per-coefficient damping multiplier for LPC stabilization.
 pub(crate) const LPC_DAMPING_FACTOR: f64 = 0.999;
 
@@ -165,6 +171,16 @@ where
 }
 
 /// Predict `extra` forward samples via LPC with finite-value guards.
+///
+/// An unstable fit (a pole on or outside the unit circle, which Burg can
+/// produce on ill-conditioned near-silent windows and legitimately produces
+/// on growing ones) makes the recursion diverge exponentially; the per-sample
+/// finite guard alone lets values reach ~1e308 while still "finite", and such
+/// magnitudes overflow downstream DFT convolution into whole NaN blocks. Once
+/// any prediction exceeds the seed's own peak by
+/// [`EXTRAPOLATION_DIVERGENCE_HEADROOM`], the predictor has diverged and every
+/// later value is garbage, so the remainder of the prediction is filled with
+/// silence instead.
 pub(crate) fn extrapolate_forward<T>(input: &[T], extra: usize, fallback: ExtrapolateFallback) -> Vec<T>
 where
     T: Float,
@@ -181,6 +197,12 @@ where
     let mut work = input.to_vec();
     let mut output = Vec::with_capacity(extra);
 
+    let seed_peak = input
+        .iter()
+        .fold(T::zero(), |acc, sample| acc.max(sample.abs()));
+    let headroom = T::from(EXTRAPOLATION_DIVERGENCE_HEADROOM).unwrap_or_else(T::one);
+    let divergence_bound = seed_peak * headroom;
+
     for _ in 0..extra {
         let base = work.len().saturating_sub(lpc.len());
         let mut next = T::zero();
@@ -188,6 +210,11 @@ where
             next = next - work[base + idx] * *coeff;
         }
         let next = if next.is_finite() { next } else { T::zero() };
+        if next.abs() > divergence_bound {
+            // Diverged: the rest of the prediction would only grow further.
+            output.resize(extra, T::zero());
+            return output;
+        }
         work.push(next);
         output.push(next);
     }
@@ -315,5 +342,33 @@ mod tests {
         assert_no_nans(&predicted, "lpc::test_extrapolate_backward_length_and_finite predicted");
         assert_eq!(predicted.len(), 24);
         assert!(predicted.iter().all(|v| v.is_finite()));
+    }
+
+    #[test]
+    fn test_extrapolate_forward_divergence_is_clamped() {
+        // A geometrically growing seed makes Burg fit a predictor with a pole
+        // outside the unit circle: it honestly models the growth, so the
+        // recursion explodes exponentially over a long prediction span. The
+        // per-sample is_finite guard alone lets values reach ~1e290 (still
+        // finite) before overflow; downstream DFT convolution then overflows
+        // to NaN across an entire output block (observed in production on a
+        // real 192 kHz track whose near-silent fade-in produced an unstable
+        // fit: the 4x oversampled downsample emitted one full output chunk,
+        // 1,241,856 samples per channel, of NaN). Predictions must stay
+        // bounded by a small multiple of the seed's own peak, with the
+        // diverged tail settling to silence.
+        let seed: Vec<f64> = (0..512).map(|i| 1e-9 * 1.05f64.powi(i)).collect();
+        let seed_peak = seed.iter().fold(0.0f64, |a, s| a.max(s.abs()));
+        let predicted = extrapolate_forward(&seed, 2_000_000, ExtrapolateFallback::Hold);
+        assert_eq!(predicted.len(), 2_000_000);
+        assert!(
+            predicted.iter().all(|v| v.is_finite()),
+            "predictions must stay finite"
+        );
+        let max_predicted = predicted.iter().fold(0.0f64, |a, s| a.max(s.abs()));
+        assert!(
+            max_predicted <= seed_peak * EXTRAPOLATION_DIVERGENCE_HEADROOM,
+            "diverged prediction reached {max_predicted:e} from a seed peak of {seed_peak:e}"
+        );
     }
 }


### PR DESCRIPTION
## Summary

The LPC edge extrapolation can diverge and poison downstream DFT output with NaN. This PR clamps the divergence at its source, with a regression test.

Thanks for ardftsrc, by the way. It is the best-sounding resampler we have measured, and this is the only issue we have hit with it in heavy production use.

## The bug

`extrapolate_forward` runs the Burg-fit predictor one sample at a time. When the fit is unstable (a pole on or outside the unit circle), the recursion grows exponentially. The existing `is_finite` guard only zeroes a value after it has already overflowed to inf/NaN, so predictions can legitimately reach ~1e308 while still counting as finite. When those huge pre-roll samples enter the DFT convolution, the transform overflows and an entire output block comes back NaN.

Two ways to get an unstable fit in practice:

- A seed window that genuinely grows (the fit honestly models the growth; the new test uses this for determinism).
- An ill-conditioned near-silent seed window, where f64 roundoff in the Burg recursion lands a pole outside the unit circle. This is the production case we hit.

## Production observation

Downsampling real 192 kHz material 4x back to 192 kHz with the maximum-quality profile (quality 2,483,712), the first `process_chunk` call returned one full output chunk (1,241,856 samples per channel) of NaN. The trigger was the track's near-silent fade-in: `synthesize_start_context` extrapolated roughly 5M pre-roll samples from an unstable fit. Supplying explicit `.pre()` context made the same conversion clean, which pinned the extrapolation as the source. Short inputs that skip the chunked path never hit it, so the failure looks content- and length-dependent from the outside and was fairly painful to localize.

## The fix

A prediction that exceeds the seed window's own peak by `EXTRAPOLATION_DIVERGENCE_HEADROOM` (8x) can only come from a diverged predictor, and every later value would just grow further, so the remainder of the prediction is filled with silence. Stable fits never cross the bound and are byte-identical before and after this change; we verified that against our own bit-exact golden renders.

## Test

`test_extrapolate_forward_divergence_is_clamped` drives a geometric seed through a 2M-sample prediction: without the clamp the max prediction reaches 1.8e308; with it, predictions stay within 8x of the seed peak and the tail is silence. The full existing suite (101 tests) passes unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
